### PR TITLE
small fixes for security reports

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "run-ci" ]
   pull_request:
     branches: [ "main" ]
   schedule:
@@ -59,7 +59,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,6 @@
-# .github/workflows/ci.yml
 name: Deploy to comunicore.mooo.com
+permissions:
+  contents: read
 
 on:
   push:
@@ -11,10 +12,10 @@ jobs:
     # build frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -33,7 +34,7 @@ jobs:
 
       # build backend
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
           cache-dependency-path: ./backend/go.sum

--- a/.github/workflows/push_and_pull_requests_ci.yml
+++ b/.github/workflows/push_and_pull_requests_ci.yml
@@ -1,5 +1,7 @@
 # .github/workflows/ci.yml
 name: CI Checks
+permissions:
+  contents: read
 
 on:
   push:
@@ -16,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -51,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
           cache-dependency-path: ./backend/go.sum

--- a/backend/internal/handler/ogen_handler.go
+++ b/backend/internal/handler/ogen_handler.go
@@ -60,7 +60,7 @@ func NewSecurityHandler(jwtService *jwtService.JwtAuthorizator) *securityHandler
 func (h *securityHandler) HandleCookieAuth(
 	ctx context.Context, operationName forumApi.OperationName, t forumApi.CookieAuth) (context.Context, error) {
 
-	fmt.Printf("Cookie Auth with operation name %s and APIKey %s\n", operationName, t.APIKey)
+	fmt.Printf("Cookie Auth with operation name %s\n", operationName)
 	global := GlobalContextFromContext(ctx)
 	if global == nil {
 		return ctx, ogenerrors.ErrSecurityRequirementIsNotSatisfied


### PR DESCRIPTION
PR с мелкими исправлениями косяков, о которых сообщил автоматический сканер уязвимостей GitHub.
Также настроил, чтобы push в ветку `run-ci` запускал все тесты CI.
- делаем push,
- смотрим отчеты,
- удаляем ветку.
В результате сообщения об уязвимостях и ошибках всплывут не в момент создания PR, а сразу.