### PR TITLE
added CORS support

### DIFF
--- a/backend/config/server-config.toml
+++ b/backend/config/server-config.toml
@@ -11,6 +11,8 @@ host = "::1"
 port = 8080
 # default "http://localhost:8080", cmd --server-baseurl, env FORUM_SERVER_BASEURL
 baseurl = "http://localhost:8080"
+# default "" (CORS disabled), cmd --server-permitted-origin, env FORUM_SERVER_PERMITTED_ORIGIN
+permittedOrigin = ""
 # no default, must by nonempty, cmd --server-jwtsecret, env FORUM_SERVER_JWTSECRET
 jwtsecret = ""
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/ogen-go/ogen v1.20.1
 	github.com/pelletier/go-toml/v2 v2.2.4
+	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -169,6 +169,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
 github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/backend/internal/handler/ogen_handler.go
+++ b/backend/internal/handler/ogen_handler.go
@@ -11,6 +11,8 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/rs/cors"
+
 	forumApi "github.com/hetagdarchiev/forum-interaction-analytics/backend/internal/handler/generated"
 	"github.com/hetagdarchiev/forum-interaction-analytics/backend/internal/lib/config"
 	"github.com/ogen-go/ogen/ogenerrors"
@@ -138,11 +140,23 @@ func RegisterOgenRoutes(mux *http.ServeMux, config *config.AppConfig) {
 	if err != nil {
 		panic(err)
 	}
-	mux.Handle("/api/", WithGlobalContext(srv))
+	apiHandler := WithGlobalContext(srv)
+
+	fmt.Printf("cors enabled for origins %s\n", config.Server.PermittedOrigin)
+	if len(config.Server.PermittedOrigin) > 0 {
+		fmt.Printf("cors enabled for origins %s\n", config.Server.PermittedOrigin)
+		corsHandler := cors.New(cors.Options{
+			AllowedOrigins:   []string{config.Server.PermittedOrigin},
+			AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+			AllowedHeaders:   []string{"Authorization", "Content-Type"},
+			AllowCredentials: true,
+		})
+		apiHandler = corsHandler.Handler(apiHandler)
+	}
+	mux.Handle("/api/", apiHandler)
 }
 
 // Thread handlers
-
 func (h *OgenHandler) ThreadAddPost(ctx context.Context, req *forumApi.ThreadCreatePostRequest, params forumApi.ThreadAddPostParams) (forumApi.ThreadAddPostRes, error) {
 	return h.threadsHandler.ThreadAddPost(ctx, req, params)
 }

--- a/backend/internal/lib/config/cmd_parse.go
+++ b/backend/internal/lib/config/cmd_parse.go
@@ -22,10 +22,11 @@ type CmdConfig struct {
 	DatabasePassword *string
 	DatabaseName     *string
 	// http server
-	ServerHost      *string
-	ServerPort      *int
-	ServerBaseURL   *string // "http://foo.com", "http://foo.com:8080"
-	ServerJwtSecret *string
+	ServerHost            *string
+	ServerPort            *int
+	ServerBaseURL         *string // "http://foo.com", "http://foo.com:8080"
+	ServerPermittedOrigin *string // CORS origin: "http://test.com" or "http://site.me:8080"
+	ServerJwtSecret       *string
 }
 
 // CmdParse parses command-line arguments and returns a CmdConfig struct.
@@ -40,6 +41,9 @@ func CmdParse() *CmdConfig {
 	serverHost := flag.String("server-host", "", "http server host")
 	serverPort := flag.Int("server-port", 0, "http server port")
 	serverBaseURL := flag.String("server-baseurl", "", "http server base URL (e.g. \"https://site.com\", \"http://site.com:8080\")")
+	serverPermittedOrigin := flag.String(
+		"server-permitted-origin", "",
+		"http server permitted extra single origin (e.g. \"http://localhost:3000\" or \"http://site.com\")")
 	serverJwtSecret := flag.String("server-jwtsecret", "", "http server jwt secret")
 
 	flag.Parse()
@@ -53,10 +57,11 @@ func CmdParse() *CmdConfig {
 		DatabasePassword: dbPassword,
 		DatabaseName:     dbName,
 		// http server
-		ServerHost:      serverHost,
-		ServerPort:      serverPort,
-		ServerBaseURL:   serverBaseURL,
-		ServerJwtSecret: serverJwtSecret,
+		ServerHost:            serverHost,
+		ServerPort:            serverPort,
+		ServerBaseURL:         serverBaseURL,
+		ServerPermittedOrigin: serverPermittedOrigin,
+		ServerJwtSecret:       serverJwtSecret,
 	}
 }
 
@@ -99,10 +104,11 @@ func (db *DatabaseConfig) DSN() string {
 }
 
 type ServerConfig struct {
-	Host      string
-	Port      int
-	BaseURL   string
-	JwtSecret string
+	Host            string
+	Port            int
+	BaseURL         string
+	PermittedOrigin string
+	JwtSecret       string
 }
 
 func (srv *ServerConfig) check(cmd *CmdConfig) error {
@@ -110,6 +116,8 @@ func (srv *ServerConfig) check(cmd *CmdConfig) error {
 	srv.Port = mergeCmdEnvCurrentDefaultInt(cmd.ServerPort, "FORUM_SERVER_PORT", srv.Port, 8080)
 	srv.BaseURL = mergeCmdEnvCurrentDefaultString(
 		cmd.ServerBaseURL, "FORUM_SERVER_BASEURL", srv.BaseURL, "http://localhost:8080")
+	srv.PermittedOrigin = mergeCmdEnvCurrentDefaultString(
+		cmd.ServerPermittedOrigin, "FORUM_SERVER_PERMITTED_ORIGIN", srv.PermittedOrigin, "")
 	srv.JwtSecret = mergeCmdEnvCurrentDefaultString(cmd.ServerJwtSecret, "FORUM_SERVER_JWTSECRET", srv.JwtSecret, "")
 
 	if srv.Port <= 0 {


### PR DESCRIPTION
Для включения CORS в конфиге, переменной окружения или командной строке нужно передать дополнительный `Origin`, которому будет разрешено делать запросы к серверу. Основной `Origin` (домен странички с которой делаются запросы) туда писать не нужно, потому что это не Cross Origin и CORS на него не срабатывает.