### PR TITLE
changed push_and_pull_requests_ci.yml to eliminate extra runs

### DIFF
--- a/.github/workflows/push_and_pull_requests_ci.yml
+++ b/.github/workflows/push_and_pull_requests_ci.yml
@@ -5,11 +5,9 @@ permissions:
 
 on:
   push:
-    branches-ignore:
-      - 'wip**'
-      - deploy
+    branches: [ "main", "run-ci" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
 
 jobs:
   frontend:


### PR DESCRIPTION
Было слишком много запусков тестов. Push в любую ветку, Pull Request в main (там почему-то отдельный коммит) и merge в main (по сути тот же push, но уже в main). Т.е. на каждый push делалось 3 проверки. Сейчас только Pull Request и Push в main (там будет merge, т.е. могут добавиться другие коммиты, которые были приняты в main, пока PR ждал проверки, а, значит, проверка того, что получилось в результате также полезна).

Ветка `deploy` так и осталась. Ветка `run-ci` тоже как и раньше запускает тесты, если нужно их запустить без создания PR.