### PR TITLE
Feat/create posts

### DIFF
--- a/frontend/src/app/(home)/editor/page.tsx
+++ b/frontend/src/app/(home)/editor/page.tsx
@@ -1,9 +1,132 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
 import { TextEditor } from '@/features/text-editor';
+import { threadCreateMutation } from '@/shared/api/generated/@tanstack/react-query.gen';
+import { useAuth } from '@/shared/hooks/useAuth';
+import { ErrorMessage } from '@/shared/ui/ErrorMessage';
+import { Input } from '@/shared/ui/Input';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+const TITLE_MAX_LENGTH = 120;
 
 export default function EditorPage() {
+  const [title, setTitle] = useState('');
+  const [localError, setLocalError] = useState('');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const { isAuthenticated, isLoading } = useAuth();
+
+  const { mutateAsync, isPending } = useMutation(threadCreateMutation());
+
+  const handleSubmit = async (event: FormEvent<HTMLElement>) => {
+    event.preventDefault();
+
+    if (!isAuthenticated) {
+      setLocalError(
+        'Только авторизованные пользователи могут публиковать посты',
+      );
+      return;
+    }
+
+    const normalizedTitle = title.trim();
+    const markdown = (
+      document.getElementById('markdown-editor') as HTMLTextAreaElement | null
+    )?.value;
+
+    if (!normalizedTitle) {
+      setLocalError('Введите заголовок поста');
+      return;
+    }
+
+    if (!markdown?.trim()) {
+      setLocalError('Добавьте текст поста');
+      return;
+    }
+
+    setLocalError('');
+
+    try {
+      const createdThread = await mutateAsync({
+        body: {
+          title: normalizedTitle,
+          content: markdown,
+        },
+      });
+
+      await queryClient.invalidateQueries({
+        predicate: (query) => {
+          const firstKey = query.queryKey[0];
+          return (
+            typeof firstKey === 'object' &&
+            firstKey !== null &&
+            '_id' in firstKey &&
+            firstKey._id === 'threadsList'
+          );
+        },
+      });
+
+      router.push(`/posts/${createdThread.id}`);
+    } catch {
+      setLocalError('Не удалось опубликовать пост. Попробуйте снова.');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <main className='w-full py-2'>
+        <section className='mx-auto flex w-full max-w-5xl flex-col gap-y-3'>
+          <p className='text-gray-80'>Проверяем авторизацию...</p>
+        </section>
+      </main>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <main className='w-full py-2'>
+        <section className='mx-auto flex w-full max-w-5xl flex-col gap-y-3'>
+          <h1 className='text-2xl font-bold'>Публикация постов недоступна</h1>
+          <p className='text-gray-80'>
+            Чтобы создавать посты, войдите в аккаунт или зарегистрируйтесь.
+          </p>
+          <div className='flex gap-3'>
+            <Link
+              href='/login'
+              className='bg-blue-16 hover:bg-blue-20 inline-flex w-fit items-center justify-center rounded-md px-5 py-3 text-center font-bold text-white duration-200'
+            >
+              Войти
+            </Link>
+            <Link
+              href='/registration'
+              className='bg-blue-16 hover:bg-blue-20 inline-flex w-fit items-center justify-center rounded-md px-5 py-3 text-center font-bold text-white duration-200'
+            >
+              Регистрация
+            </Link>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
   return (
-    <main className='w-full py-2'>
-      <TextEditor />
+    <main className='w-full py-2' onSubmitCapture={handleSubmit}>
+      <section className='mx-auto flex w-full max-w-5xl flex-col gap-y-3'>
+        <Input
+          name='thread-title'
+          icon={''}
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          placeholder='Заголовок поста'
+          maxLength={TITLE_MAX_LENGTH}
+          disabled={isPending}
+        />
+        {localError && <ErrorMessage error={localError} />}
+        <TextEditor />
+      </section>
     </main>
   );
 }

--- a/frontend/src/app/(home)/editor/page.tsx
+++ b/frontend/src/app/(home)/editor/page.tsx
@@ -1,79 +1,12 @@
 'use client';
 
-import { FormEvent, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
-import { TextEditor } from '@/features/text-editor';
-import { threadCreateMutation } from '@/shared/api/generated/@tanstack/react-query.gen';
 import { useAuth } from '@/shared/hooks/useAuth';
-import { ErrorMessage } from '@/shared/ui/ErrorMessage';
-import { Input } from '@/shared/ui/Input';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-
-const TITLE_MAX_LENGTH = 120;
+import { CreateThreadEditor } from '@/widgets/create-thread-editor/ui';
 
 export default function EditorPage() {
-  const [title, setTitle] = useState('');
-  const [localError, setLocalError] = useState('');
-  const queryClient = useQueryClient();
-  const router = useRouter();
   const { isAuthenticated, isLoading } = useAuth();
-
-  const { mutateAsync, isPending } = useMutation(threadCreateMutation());
-
-  const handleSubmit = async (event: FormEvent<HTMLElement>) => {
-    event.preventDefault();
-
-    if (!isAuthenticated) {
-      setLocalError(
-        'Только авторизованные пользователи могут публиковать посты',
-      );
-      return;
-    }
-
-    const normalizedTitle = title.trim();
-    const markdown = (
-      document.getElementById('markdown-editor') as HTMLTextAreaElement | null
-    )?.value;
-
-    if (!normalizedTitle) {
-      setLocalError('Введите заголовок поста');
-      return;
-    }
-
-    if (!markdown?.trim()) {
-      setLocalError('Добавьте текст поста');
-      return;
-    }
-
-    setLocalError('');
-
-    try {
-      const createdThread = await mutateAsync({
-        body: {
-          title: normalizedTitle,
-          content: markdown,
-        },
-      });
-
-      await queryClient.invalidateQueries({
-        predicate: (query) => {
-          const firstKey = query.queryKey[0];
-          return (
-            typeof firstKey === 'object' &&
-            firstKey !== null &&
-            '_id' in firstKey &&
-            firstKey._id === 'threadsList'
-          );
-        },
-      });
-
-      router.push(`/posts/${createdThread.id}`);
-    } catch {
-      setLocalError('Не удалось опубликовать пост. Попробуйте снова.');
-    }
-  };
 
   if (isLoading) {
     return (
@@ -113,19 +46,9 @@ export default function EditorPage() {
   }
 
   return (
-    <main className='w-full py-2' onSubmitCapture={handleSubmit}>
+    <main className='w-full py-2'>
       <section className='mx-auto flex w-full max-w-5xl flex-col gap-y-3'>
-        <Input
-          name='thread-title'
-          icon={''}
-          value={title}
-          onChange={(event) => setTitle(event.target.value)}
-          placeholder='Заголовок поста'
-          maxLength={TITLE_MAX_LENGTH}
-          disabled={isPending}
-        />
-        {localError && <ErrorMessage error={localError} />}
-        <TextEditor />
+        <CreateThreadEditor />
       </section>
     </main>
   );

--- a/frontend/src/app/(home)/page.tsx
+++ b/frontend/src/app/(home)/page.tsx
@@ -1,17 +1,10 @@
 'use client';
 
-import Link from 'next/link';
-
-import { useAuth } from '@/shared/hooks/useAuth';
 import { PostList } from '@/widgets/post-list';
 
 export default function Home() {
-  const { isAuthenticated } = useAuth();
   return (
     <main className='grow'>
-      <Link href={isAuthenticated ? '/editor' : '/registration'}>
-        Text editor
-      </Link>
       <PostList />
     </main>
   );

--- a/frontend/src/entities/post/ui/post-content/post-content.tsx
+++ b/frontend/src/entities/post/ui/post-content/post-content.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import {ReactNode} from "react";
 
+import { renderHtml } from '@/shared/lib/markdown';
+
 interface PostContentProps {
   id: string | number;
   title: string;
@@ -14,8 +16,9 @@ export const PostContent = ({ id, title, children }: PostContentProps) => (
         {title}
       </h2>
     </Link>
-    <p className='line-clamp-6 text-base leading-6 font-light tracking-wider'>
-      {children}
-    </p>
+    <div
+      className='line-clamp-6 text-base leading-6 font-light tracking-wider'
+      dangerouslySetInnerHTML={{ __html: renderHtml(String(children ?? '')) }}
+    />
   </div>
 );

--- a/frontend/src/features/create-thread/index.ts
+++ b/frontend/src/features/create-thread/index.ts
@@ -1,0 +1,1 @@
+export { CreateThreadForm } from './ui/CreateThreadForm';

--- a/frontend/src/features/create-thread/model/useCreateThreadForm.ts
+++ b/frontend/src/features/create-thread/model/useCreateThreadForm.ts
@@ -1,0 +1,71 @@
+import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { threadCreateMutation } from '@/shared/api/generated/@tanstack/react-query.gen';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+const TITLE_MAX_LENGTH = 120;
+
+export function useCreateThreadForm() {
+  const [title, setTitle] = useState('');
+  const [localError, setLocalError] = useState('');
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const { mutateAsync, isPending } = useMutation(threadCreateMutation());
+
+  const handleSubmit = async (event: FormEvent<HTMLElement>) => {
+    event.preventDefault();
+
+    const normalizedTitle = title.trim();
+    const markdown = (
+      document.getElementById('markdown-editor') as HTMLTextAreaElement | null
+    )?.value;
+
+    if (!normalizedTitle) {
+      setLocalError('Введите заголовок поста');
+      return;
+    }
+
+    if (!markdown?.trim()) {
+      setLocalError('Добавьте текст поста');
+      return;
+    }
+
+    setLocalError('');
+
+    try {
+      const createdThread = await mutateAsync({
+        body: {
+          title: normalizedTitle,
+          content: markdown,
+        },
+      });
+
+      await queryClient.invalidateQueries({
+        predicate: (query) => {
+          const firstKey = query.queryKey[0];
+          return (
+            typeof firstKey === 'object' &&
+            firstKey !== null &&
+            '_id' in firstKey &&
+            firstKey._id === 'threadsList'
+          );
+        },
+      });
+
+      router.push(`/posts/${createdThread.id}`);
+    } catch {
+      setLocalError('Не удалось опубликовать пост. Попробуйте снова.');
+    }
+  };
+
+  return {
+    title,
+    localError,
+    isPending,
+    titleMaxLength: TITLE_MAX_LENGTH,
+    setTitle,
+    handleSubmit,
+  };
+}

--- a/frontend/src/features/create-thread/ui/CreateThreadForm.tsx
+++ b/frontend/src/features/create-thread/ui/CreateThreadForm.tsx
@@ -31,6 +31,7 @@ export function CreateThreadForm({ children }: CreateThreadFormProps) {
         placeholder='Заголовок поста'
         maxLength={titleMaxLength}
         disabled={isPending}
+        className='mb-2.5 bg-white'
       />
       {localError && <ErrorMessage error={localError} />}
       {children}

--- a/frontend/src/features/create-thread/ui/CreateThreadForm.tsx
+++ b/frontend/src/features/create-thread/ui/CreateThreadForm.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+import { ErrorMessage } from '@/shared/ui/ErrorMessage';
+import { Input } from '@/shared/ui/Input';
+
+import { useCreateThreadForm } from '../model/useCreateThreadForm';
+
+type CreateThreadFormProps = {
+  children?: ReactNode;
+};
+
+export function CreateThreadForm({ children }: CreateThreadFormProps) {
+  const {
+    title,
+    localError,
+    isPending,
+    titleMaxLength,
+    setTitle,
+    handleSubmit,
+  } = useCreateThreadForm();
+
+  return (
+    <div onSubmitCapture={handleSubmit}>
+      <Input
+        name='thread-title'
+        icon={''}
+        value={title}
+        onChange={(event) => setTitle(event.target.value)}
+        placeholder='Заголовок поста'
+        maxLength={titleMaxLength}
+        disabled={isPending}
+      />
+      {localError && <ErrorMessage error={localError} />}
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/features/text-editor/ui/components/preview/Preview.tsx
+++ b/frontend/src/features/text-editor/ui/components/preview/Preview.tsx
@@ -2,7 +2,7 @@
 
 import { MouseEvent, useMemo } from 'react';
 
-import { renderHtml } from '../../../model/lib/markdown';
+import { renderHtml } from '@/shared/lib/markdown';
 
 import styles from './preview.module.css';
 

--- a/frontend/src/shared/lib/markdown/index.ts
+++ b/frontend/src/shared/lib/markdown/index.ts
@@ -1,0 +1,8 @@
+import { md } from './parser';
+import { sanitize } from './sanitize';
+
+export function renderHtml(markdown: string) {
+  const html = md.render(markdown);
+
+  return sanitize(html);
+}

--- a/frontend/src/shared/lib/markdown/parser.ts
+++ b/frontend/src/shared/lib/markdown/parser.ts
@@ -1,0 +1,44 @@
+import hljs from 'highlight.js';
+import MarkdownIt from 'markdown-it';
+
+export const md: MarkdownIt = new MarkdownIt({
+  html: false,
+  linkify: true,
+  typographer: true,
+  highlight: function (str, lang) {
+    if (lang && hljs.getLanguage(lang)) {
+      try {
+        return (
+          `<pre><code class="hljs language-${lang}">` +
+          hljs.highlight(str, { language: lang, ignoreIllegals: true }).value +
+          '</code></pre>'
+        );
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    return (
+      '<pre><code class="hljs">' + md.utils.escapeHtml(str) + '</code></pre>'
+    );
+  },
+});
+
+md.renderer.rules.link_open = (tokens, idx, options, _, self) => {
+  const aIndex = tokens[idx].attrIndex('target');
+  const token = tokens[idx];
+
+  const hrefIndex = token.attrIndex('href');
+  const href = hrefIndex >= 0 ? token.attrs![hrefIndex][1] : '';
+
+  if (aIndex < 0) {
+    tokens[idx].attrPush(['target', '_blank']);
+  } else {
+    tokens[idx].attrs![aIndex][1] = '_blank';
+  }
+  tokens[idx].attrPush(['rel', 'noopener noreferrer']);
+
+  token.attrPush(['data-confirm-link', href]);
+
+  return self.renderToken!(tokens, idx, options);
+};

--- a/frontend/src/shared/lib/markdown/sanitize.ts
+++ b/frontend/src/shared/lib/markdown/sanitize.ts
@@ -1,0 +1,6 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+export const sanitize = (html: string) =>
+  DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+  });

--- a/frontend/src/shared/ui/Input/Input.tsx
+++ b/frontend/src/shared/ui/Input/Input.tsx
@@ -18,7 +18,7 @@ export const Input = forwardRef<HTMLInputElement, IInputProps>((props, ref) => {
         className={`${className} bg-light-fc focus-within:ring-gray-80/30 flex h-full w-full max-w-125 items-center gap-x-2.5 rounded-sm px-5 py-3 transition-all duration-200 focus-within:ring-2 ${error ? 'border-red-500' : ''}`}
         htmlFor={rest.name}
       >
-        <Image src={icon} alt='' width={24} height={24} />
+        {icon && <Image src={icon} alt='' width={24} height={24} unoptimized />}
         <input
           className='text-gray-80 placeholder:text-gray-80 w-full bg-transparent text-[18px] outline-none'
           ref={ref}

--- a/frontend/src/widgets/create-thread-editor/ui/CreateThreadEditor.tsx
+++ b/frontend/src/widgets/create-thread-editor/ui/CreateThreadEditor.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { CreateThreadForm } from '@/features/create-thread';
+import { TextEditor } from '@/features/text-editor';
+
+export function CreateThreadEditor() {
+  return (
+    <CreateThreadForm>
+      <TextEditor />
+    </CreateThreadForm>
+  );
+}

--- a/frontend/src/widgets/create-thread-editor/ui/index.ts
+++ b/frontend/src/widgets/create-thread-editor/ui/index.ts
@@ -1,0 +1,1 @@
+export { CreateThreadEditor } from './CreateThreadEditor';


### PR DESCRIPTION
# 🚀 Pull Request: Реализация функционала создания постов

## 🎯 Главная задача
Внедрение полноценной возможности публикации постов в приложении.

---

## ✅ Что реализовано

### 1. Функционал создания постов
- Реализована логика публикации через мутацию `threadCreateMutation`.
- Добавлена валидация данных, обработка ошибок и автоматический редирект после создания.
- **Интеграция**: Внедрен текстовый редактор, разработанный [**PalamarNazar**.](https://github.com/PalamarNazar) 

### 2. Рендеринг контента (Markdown)
- Чтобы посты выглядели корректно, добавлен движок **Markdown** в `shared/lib`.
- Теперь просмотре постов поддерживается форматирование: заголовки, списки, ссылки.
- Реализована **санитизация** HTML для защиты от XSS.

### 3. Архитектурные изменения (FSD)
Для обеспечения стабильности фичи создания постов проведен рефакторинг:
- **Выделена фича `create-thread`**: содержит в себе всю бизнес-логику и модель поведения формы.
- **Создан виджет `create-thread-editor`**: объединяет форму создания и текстовый редактор. Это решило проблему зависимости между фичами и сделало код расширяемым.
- **Обновлен UI-слой**: компонент `Input` стал гибче за счет опциональных иконок.

---

## 📂 Обзор затронутых файлов
- `editor/page.tsx` — точка входа страницы создания.
- `features/create-thread` — бизнес-логика создания (hooks, validation).
- `widgets/create-thread-editor` — сборка интерфейса редактора.
- `shared/lib/markdown` — движок для обработки текста постов.
- `shared/ui/Input` — базовый компонент ввода с поддержкой опциональных элементов.


